### PR TITLE
Hotfix new cron

### DIFF
--- a/scheduler/admin.py
+++ b/scheduler/admin.py
@@ -110,7 +110,8 @@ class JobAdmin(admin.ModelAdmin):
         job_names = []
         for obj in queryset:
             kwargs = obj.schedule_kwargs()
-            obj.get_queue2().enqueue(
+            obj.get_queue2().enqueue_at(
+                utc(now()),
                 obj.callable_func(),
                 *obj.parse_args(),
                 **kwargs

--- a/scheduler/admin.py
+++ b/scheduler/admin.py
@@ -110,8 +110,7 @@ class JobAdmin(admin.ModelAdmin):
         job_names = []
         for obj in queryset:
             kwargs = obj.schedule_kwargs()
-            obj.get_queue2().enqueue_at(
-                utc(now()),
+            obj.get_queue2().enqueue(
                 obj.callable_func(),
                 *obj.parse_args(),
                 **kwargs


### PR DESCRIPTION
replaces PR #78 

only add the on_success and on_failure callback.

Note: this does not address Repeatable jobs (We never use them) but adding it would be simple. @cunla let me know If you want it as well.

Thanks for the opportunity!
