### PR TITLE
Re-schedule all jobs that might have lost cron-scheduling by any reason

### DIFF
--- a/scheduler/models.py
+++ b/scheduler/models.py
@@ -23,9 +23,10 @@ def callback_save_job(job, connection, result, *args, **kwargs):
     if model_name is None:
         return
     model = apps.get_model(app_label='scheduler', model_name=model_name)
-    scheduled_job = model.objects.filter(job_id=job.id).first()
-    if scheduled_job:
-        scheduled_job.save()
+    enabled_jobs = model.objects.filter(enabled=True)
+    for job in enabled_jobs:
+        if not job.is_scheduled() and model_name != 'ScheduledJob':  # No need to reschedule if ScheduledJob
+            job.save()
 
 
 class BaseJobArg(models.Model):


### PR DESCRIPTION
Motivation: If a (repeatable/cron) job loses even one link in the series of scheduling, the job will never run after that.
in the previous PR, I tried to re-schedule the same job that was executed.
Unfortunately, this method might be perfect in theory, but if anything happens, the cron/repeatable job becomes "enabled but not scheduled".
This is a slight modification to allow any finished job to re-heal other jobs.

@cunla What's your insight on this?

Perhaps the end-goal would be to have an "internal" repeatable job (say, every 1 minute) that check for the health of all the other jobs and heals them as necessary?

I did not include tests, but happy to do it (I've tested manually, namely: delete all the jobs in the scheduled registry but 1, and after that one runs, you will get all the scheduled registry back as per the enabled jobs in cron/repeatable. We only use crons though)