### PR TITLE
fixed validation of `callable` field

### DIFF
--- a/scheduler/models.py
+++ b/scheduler/models.py
@@ -155,7 +155,7 @@ class BaseJob(TimeStampedModel):
     def clean_callable(self):
         try:
             self.callable_func()
-        except TypeError:
+        except Exception:
             raise ValidationError({
                 'callable': ValidationError(
                     _('Invalid callable, must be importable'), code='invalid')


### PR DESCRIPTION
fixed validation of `callable` field when passed not valid string to import